### PR TITLE
Add .cache to gitignore

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -122,7 +122,7 @@ async function main(): Promise<void> {
     )
 
     console.log('📄 Adding .gitignore')
-    await writeFile('.gitignore', ['dist/', 'node_modules/', ''].join('\n'))
+    await writeFile('.gitignore', ['dist/', 'node_modules/', '.cache/', ''].join('\n'))
 
     if (await exists('package.json')) {
         console.log('📄 package.json already exists, skipping creation')


### PR DESCRIPTION
I found it quite annoying to have .cache tracked by git. Is there any reason it should not be ignored?