### PR TITLE
docs: update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Create Sourcegraph extension
 
-[![npm](https://img.shields.io/npm/v/@sourcegraph/create-extension.svg)](https://www.npmjs.com/package/@sourcegraph/create-extension)
-[![downloads](https://img.shields.io/npm/dt/@sourcegraph/create-extension.svg)](https://www.npmjs.com/package/@sourcegraph/create-extension)
+[![npm](https://img.shields.io/npm/v/create-sourcegraph-extension.svg)](https://www.npmjs.com/package/create-sourcegraph-extension)
+[![downloads](https://img.shields.io/npm/dt/create-sourcegraph-extension.svg)](https://www.npmjs.com/package/create-sourcegraph-extension)
 [![build](https://travis-ci.org/sourcegraph/create-extension.svg?branch=master)](https://travis-ci.org/sourcegraph/create-extension)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
We previously used badges for the deprecated @sourcegraph/create-extension.